### PR TITLE
Fix test setup and html class

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <h1>CoinMarket</h1>
   <input 
   type="text" 
-  class="form-control bg-dark text-light border-0 my-4 text-center rounder-0"
+  class="form-control bg-dark text-light border-0 my-4 text-center rounded-0"
   (keyup)="searchCoin()"
   [(ngModel)]="searchText"
   >

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -7,6 +9,10 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      imports: [
+        HttpClientTestingModule,
+        FormsModule
+      ]
     }).compileComponents();
   });
 
@@ -16,16 +22,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'angular-coingecko-api'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('angular-coingecko-api');
-  });
-
-  it('should render title', () => {
+  it('should render header title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('angular-coingecko-api app is running!');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('CoinMarket');
   });
 });


### PR DESCRIPTION
## Summary
- fix missing imports in `AppComponent` tests
- update tests to check header instead of old placeholder
- fix `rounded-0` class typo in component template

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685da769d3988325869c10bb9843abf7